### PR TITLE
Use absolute links

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -28,9 +28,9 @@ const style = {
 
 const Header = () => (
   <div>
-    <Link to="find_rep"> <RaisedButton label="Find Your Rep" style={style} /></Link>
-    <Link to="bill_search"><RaisedButton label="Bill Search (External)" style={style} /></Link>
-    <Link to="bill_filter"><RaisedButton label="Bill Tracker" style={style} /></Link>
+    <Link to="/find_rep"> <RaisedButton label="Find Your Rep" style={style} /></Link>
+    <Link to="/bill_search"><RaisedButton label="Bill Search (External)" style={style} /></Link>
+    <Link to="/bill_filter"><RaisedButton label="Bill Tracker" style={style} /></Link>
   </div>
 );
 


### PR DESCRIPTION
Fixes a bug where if you went to a bill detail page, then you couldn't use the links anymore. 
Basically, bill detail is at `/bills/<bill_id>` and relative links in the header were taking you to `/bills/bill_search`, which is incorrect. 